### PR TITLE
Typo in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas",
-    "scypi",
+    "scipy",
     "tkinterhtml"
 ]
 


### PR DESCRIPTION

There is a typo in pyproject.toml, where scipy is spelled 'scypi'.

